### PR TITLE
tvm-bench: Removing quant_bool variable from load_test_image

### DIFF
--- a/inception-v1-llvm-arm64-quant.py
+++ b/inception-v1-llvm-arm64-quant.py
@@ -26,8 +26,7 @@ except AttributeError:
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 dtype="uint8"
-quant_bool=False
-image_data = load_test_image(dtype, quant_bool)
+image_data = load_test_image(dtype)
 
 input_tensor = "input"
 input_shape = (1, 224, 224, 3)

--- a/inception-v3-llvm-arm32-float.py
+++ b/inception-v3-llvm-arm32-float.py
@@ -26,10 +26,9 @@ except AttributeError:
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 dtype="float32"
-quant_bool=True
 width=299
 height=299
-image_data = load_test_image(dtype, quant_bool, width, height)
+image_data = load_test_image(dtype, width, height)
 
 input_tensor = "input"
 input_shape = (1, 299, 299, 3)

--- a/inception-v3-llvm-arm32-quant.py
+++ b/inception-v3-llvm-arm32-quant.py
@@ -26,10 +26,9 @@ except AttributeError:
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 dtype="uint8"
-quant_bool=False
 width=299
 height=299
-image_data = load_test_image(dtype, quant_bool, width, height)
+image_data = load_test_image(dtype, width, height)
 
 input_tensor = "input"
 input_shape = (1, 299, 299, 3)

--- a/inception-v3-llvm-arm64-float.py
+++ b/inception-v3-llvm-arm64-float.py
@@ -26,10 +26,9 @@ except AttributeError:
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 dtype="float32"
-quant_bool=True
 width=299
 height=299
-image_data = load_test_image(dtype, quant_bool, width, height)
+image_data = load_test_image(dtype, width, height)
 
 input_tensor = "input"
 input_shape = (1, 299, 299, 3)

--- a/inception-v3-llvm-arm64-quant.py
+++ b/inception-v3-llvm-arm64-quant.py
@@ -26,10 +26,9 @@ except AttributeError:
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 dtype="uint8"
-quant_bool=False
 width=299
 height=299
-image_data = load_test_image(dtype, quant_bool, width, height)
+image_data = load_test_image(dtype, width, height)
 
 input_tensor = "input"
 input_shape = (1, 299, 299, 3)

--- a/mobilenet-v1.0.5-arm_cpu-arm32-float.py
+++ b/mobilenet-v1.0.5-arm_cpu-arm32-float.py
@@ -33,10 +33,9 @@ except AttributeError:
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 dtype="float32"
-quant_bool=True
 width=128
 height=128
-image_data = load_test_image(dtype, quant_bool, width, height)
+image_data = load_test_image(dtype, width, height)
 
 input_tensor = "input"
 input_shape = (1, 128, 128, 3)

--- a/mobilenet-v1.0.5-arm_cpu-arm32-quant.py
+++ b/mobilenet-v1.0.5-arm_cpu-arm32-quant.py
@@ -35,10 +35,9 @@ except AttributeError:
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 dtype="int8"
-quant_bool=False
 width=128
 height=128
-image_data = load_test_image(dtype, quant_bool, width, height)
+image_data = load_test_image(dtype, width, height)
 
 input_tensor = "input"
 input_shape = (1, 128, 128, 3)

--- a/mobilenet-v1.0.5-arm_cpu-arm64-quant.py
+++ b/mobilenet-v1.0.5-arm_cpu-arm64-quant.py
@@ -34,10 +34,9 @@ except AttributeError:
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 dtype="uint8"
-quant_bool=False
 width=128
 height=128
-image_data = load_test_image(dtype, quant_bool, width, height)
+image_data = load_test_image(dtype, width, height)
 
 input_tensor = "input"
 input_shape = (1, 128, 128, 3)

--- a/mobilenet-v1.0.5-llvm-arm32-float.py
+++ b/mobilenet-v1.0.5-llvm-arm32-float.py
@@ -35,11 +35,10 @@ except AttributeError:
     
 
 dtype="float32"
-quant_bool=True
 width=128
 height=128
 
-image_data = load_test_image(dtype, quant_bool, width, height)
+image_data = load_test_image(dtype, width, height)
 
 input_tensor = "input"
 input_shape = (1, 128, 128, 3)

--- a/mobilenet-v1.0.5-llvm-arm32-quant.py
+++ b/mobilenet-v1.0.5-llvm-arm32-quant.py
@@ -34,10 +34,9 @@ except AttributeError:
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 dtype="uint8"
-quant_bool=False
 width=128
 height=128
-image_data = load_test_image(dtype, quant_bool, width, height)
+image_data = load_test_image(dtype, width, height)
 
 input_tensor = "input"
 input_shape = (1, 128, 128, 3)

--- a/mobilenet-v1.0.5-llvm-arm64-float.py
+++ b/mobilenet-v1.0.5-llvm-arm64-float.py
@@ -32,10 +32,9 @@ except AttributeError:
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 dtype="float32"
-quant_bool=True
 width=128
 height=128
-image_data = load_test_image(dtype, quant_bool, width, height)
+image_data = load_test_image(dtype, width, height)
 
 input_tensor = "input"
 input_shape = (1, 128, 128, 3)

--- a/mobilenet-v1.0.5-llvm-arm64-quant.py
+++ b/mobilenet-v1.0.5-llvm-arm64-quant.py
@@ -30,10 +30,9 @@ except AttributeError:
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 dtype="uint8"
-quant_bool=False
 width=128
 height=128
-image_data = load_test_image(dtype, quant_bool, width, height)
+image_data = load_test_image(dtype, width, height)
 
 input_tensor = "input"
 input_shape = (1, 128, 128, 3)

--- a/mobilenet-v1.1-128-arm_cpu-arm64-quant.py
+++ b/mobilenet-v1.1-128-arm_cpu-arm64-quant.py
@@ -33,10 +33,9 @@ except AttributeError:
     import tflite.Model
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 dtype = "uint8"
-quant_bool = False
 width = 128
 height = 128
-image_data = load_test_image(dtype, quant_bool, width, height)
+image_data = load_test_image(dtype, width, height)
 
 input_tensor = "input"
 input_shape = (1, 128, 128, 3)

--- a/mobilenet-v1.1-128-llvm-arm32-quant.py
+++ b/mobilenet-v1.1-128-llvm-arm32-quant.py
@@ -26,10 +26,9 @@ except AttributeError:
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 dtype="uint8"
-quant_bool=False
 width=128
 height=128
-image_data = load_test_image(dtype, quant_bool, width, height)
+image_data = load_test_image(dtype, width, height)
 
 input_tensor = "input"
 input_shape = (1, 128, 128, 3)

--- a/mobilenet-v1.1-128-llvm-arm64-quant.py
+++ b/mobilenet-v1.1-128-llvm-arm64-quant.py
@@ -34,10 +34,9 @@ except AttributeError:
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 dtype="uint8"
-quant_bool="False"
 width=128
 height=128
-image_data = load_test_image(dtype, quant_bool, width, height)
+image_data = load_test_image(dtype, width, height)
 
 input_tensor = "input"
 input_shape = (1, 128, 128, 3)

--- a/mobilenet-v2-1.0-arm_cpu-arm32-float.py
+++ b/mobilenet-v2-1.0-arm_cpu-arm32-float.py
@@ -33,8 +33,7 @@ except AttributeError:
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 dtype="float32"
-quant_bool=True
-image_data = load_test_image(dtype, quant_bool)
+image_data = load_test_image(dtype)
 
 input_tensor = "input"
 input_shape = (1, 224, 224, 3)

--- a/mobilenet-v2-1.0-arm_cpu-arm64-float.py
+++ b/mobilenet-v2-1.0-arm_cpu-arm64-float.py
@@ -32,8 +32,7 @@ except AttributeError:
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 dtype="float32"
-quant_bool=True
-image_data = load_test_image(dtype, quant_bool)
+image_data = load_test_image(dtype)
 
 input_tensor = "input"
 input_shape = (1, 224, 224, 3)

--- a/mobilenet-v2-1.0-llvm-arm32-float.py
+++ b/mobilenet-v2-1.0-llvm-arm32-float.py
@@ -33,8 +33,7 @@ except AttributeError:
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 dtype="float32"
-quant_bool=True
-image_data = load_test_image(dtype, quant_bool)
+image_data = load_test_image(dtype)
 
 input_tensor = "input"
 input_shape = (1, 224, 224, 3)

--- a/mobilenet-v2-1.0-llvm-arm64-float.py
+++ b/mobilenet-v2-1.0-llvm-arm64-float.py
@@ -32,8 +32,7 @@ except AttributeError:
     tflite_model = tflite.Model.Model.GetRootAsModel(tflite_model_buf, 0)
 
 dtype="float32"
-quant_bool=True
-image_data = load_test_image(dtype, quant_bool)
+image_data = load_test_image(dtype)
 
 input_tensor = "input"
 input_shape = (1, 224, 224, 3)

--- a/util.py
+++ b/util.py
@@ -33,7 +33,7 @@ def extract(path):
     else:
         raise RuntimeError('Could not decompress the file: ' + path)
 
-def load_test_image(dtype='float32', quant_bool=False, width=224, height=224):
+def load_test_image(dtype='float32', width=224, height=224):
     image_url = 'https://github.com/dmlc/mxnet.js/blob/master/data/cat.png?raw=true'
     image_path = download_testdata(image_url, 'cat.png', module='data')
     resized_image = Image.open(image_path).resize((width, height))
@@ -44,7 +44,7 @@ def load_test_image(dtype='float32', quant_bool=False, width=224, height=224):
     # Add a dimension to the image so that we have NHWC format layout
     image_data = np.expand_dims(image_data, axis=0)
 
-    if (quant_bool==False):
+    if (dtype=='float32'):
     	# Preprocess image as described here:
     	# https://github.com/tensorflow/models/blob/edb6ed22a801665946c63d650ab9a0b23d98e1b1/research/slim/preprocessing/inception_preprocessing.py#L243
     	image_data[:, :, :, 0] = 2.0 / 255.0 * image_data[:, :, :, 0] - 1


### PR DESCRIPTION
Removing quant_bool variable from util.py, inception* and mobilenet*,
using comparison to float32 instead.

Signed-off-by: Theodore Grey <theodore.grey@linaro.org>