### PR TITLE
tvm-bench/util.py : adding get_cpu_count()

### DIFF
--- a/util.py
+++ b/util.py
@@ -27,6 +27,7 @@ from tvm.relay.op.contrib import arm_compute_lib
 from PIL import Image
 from tvm.contrib.download import download_testdata
 import cpuinfo
+import multiprocessing
 
 def parse_options(argv):
     device='llvm'
@@ -47,6 +48,10 @@ def parse_options(argv):
 def get_device_arch():
     arch = cpuinfo.get_cpu_info()['arch_string_raw']
     return arch
+
+def get_cpu_count():
+    cpu_count = multiprocessing.cpu_count()
+    return cpu_count
 
 def get_device_attributes():
     if get_device_arch() == "aarch64":


### PR DESCRIPTION
Adding get_cpu_count() function which returns an integer value for the number of available cpu's.